### PR TITLE
解决templater脚本插入文档问题

### DIFF
--- a/TEMPLATER_USAGE_GUIDE.md
+++ b/TEMPLATER_USAGE_GUIDE.md
@@ -1,0 +1,45 @@
+# Templater 脚本使用指南
+
+## 问题描述
+Obsidian的Templater插件在运行脚本时会将脚本内容插入到文档中，这通常不是我们想要的结果。
+
+## 解决方案
+
+### 方案1：修改脚本返回值（推荐）
+将脚本的返回值改为空字符串 `""`，这样Templater运行时就不会插入任何内容到文档中。
+
+**示例：**
+```javascript
+// 修改前
+return `已更新updated字段为: ${now}`;
+
+// 修改后  
+return ""; // 返回空字符串，不插入内容
+```
+
+### 方案2：使用Templater的User Scripts功能
+1. 在Templater设置中启用"User Scripts"
+2. 将脚本放在正确的目录中：
+   - Windows: `%APPDATA%\Obsidian\obsidian-xxx\templater-obsidian\scripts\`
+   - macOS: `~/Library/Application Support/obsidian-xxx/templater-obsidian/scripts/`
+   - Linux: `~/.config/obsidian-xxx/templater-obsidian/scripts/`
+
+### 方案3：使用命令面板运行脚本
+1. 按 `Ctrl/Cmd + P` 打开命令面板
+2. 输入 "Templater: Run script"
+3. 选择要运行的脚本
+4. 这样脚本会执行但不会插入内容到当前文档
+
+### 方案4：创建专门的模板文件
+如果您需要脚本输出特定内容，可以：
+1. 创建一个模板文件（如 `timestamp-template.md`）
+2. 在模板中使用 `<% tp.file.include("[[timestamp-template]]") %>`
+3. 这样只会插入模板内容，而不是脚本代码
+
+## 当前脚本说明
+`smart-update-timestamp.js` 脚本已经修改为返回空字符串，运行后不会在文档中插入任何内容。
+
+## 使用建议
+- 对于工具类脚本（如更新时间戳），建议使用方案1
+- 对于需要输出内容的脚本，建议使用方案4
+- 对于复杂的自动化任务，建议使用方案2的User Scripts功能

--- a/templater-scripts/smart-update-timestamp.js
+++ b/templater-scripts/smart-update-timestamp.js
@@ -3,7 +3,7 @@ module.exports = async function(tp) {
     const activeFile = app.workspace.getActiveFile();
     if (!activeFile) {
         new Notice("没有活动文件");
-        return "错误：没有活动文件";
+        return ""; // 返回空字符串，不插入内容
     }
     
     // 读取文件内容
@@ -31,5 +31,5 @@ module.exports = async function(tp) {
     await app.vault.modify(activeFile, updatedContent);
     
     new Notice(`已更新updated字段为: ${now}`);
-    return `已更新updated字段为: ${now}`;
+    return ""; // 返回空字符串，不插入内容
 };


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

This PR addresses the issue where Templater scripts insert their content or return values directly into the active document.

1.  **Modified `templater-scripts/smart-update-timestamp.js`**: Changed the script to return an empty string (`""`) instead of a message or error string. This prevents any output from the script being inserted into the document by Templater.
2.  **Added `TEMPLATER_USAGE_GUIDE.md`**: Created a new markdown file providing a comprehensive guide with four different solutions to prevent Templater scripts from inserting their content into documents, including the implemented solution.

## How To Test

1.  Open an Obsidian note.
2.  Run the `smart-update-timestamp.js` script using Templater (e.g., via a hotkey or command).
3.  Verify that:
    *   The `updated` timestamp in the frontmatter is correctly updated.
    *   A "已更新updated字段为: [timestamp]" notice is displayed.
    *   **No script content or return message is inserted into the document.**
4.  Review the `TEMPLATER_USAGE_GUIDE.md` file for clarity and accuracy of the described solutions.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

## Additional Notes

The primary goal was to stop Templater scripts from inserting unwanted content into documents, while also providing users with a detailed guide on various methods to achieve this for different use cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a70a82e-2751-4c2b-b841-6442a7cd9909">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a70a82e-2751-4c2b-b841-6442a7cd9909">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

